### PR TITLE
Moved setup credentials from kluster-toolbox.

### DIFF
--- a/utils/setup-credentials-helper.sh
+++ b/utils/setup-credentials-helper.sh
@@ -61,3 +61,14 @@ if [ ! -z "$SSH_KEY" ] ; then
     echo "Installed ssh key into $HOME/.ssh/id_rsa"
     run ssh-keygen -y -f "$HOME/.ssh/id_rsa"
 fi
+
+if [[ ! -z "${GIT_USER}" && ! -z "${GIT_PASSWORD}" ]] ; then
+    git config --global user.email ${GIT_EMAIL:-no-reply@presslabs.com}
+    git config --global user.name $GIT_USER
+
+    cat <<EOF >> ~/.netrc
+machine ${GIT_HOST:-github.com}
+       login ${GIT_USER}
+       password ${GIT_PASSWORD}
+EOF
+fi


### PR DESCRIPTION
Set git `user.email` and `user.name` and append config to the `.netrc` home file.

Related to: https://github.com/presslabs/wordpress-composer-builder/pull/1

#### Tests
- `docker run -it -v ~/go/src/github.com/presslabs/bfc/:/root/test quay.io/presslabs/bfc bash`
- `cd /root/test`
- `GIT_USER=a GIT_PASSWORD=b ./setup-credentials-helper.sh`
- `cat ~/.netrc`
- it **should** contain
```
machine github.com
       login a
       password b
```
